### PR TITLE
UI Improvement for ResultView

### DIFF
--- a/WpfApplication1/Views/SpecialViews/ResultView.xaml
+++ b/WpfApplication1/Views/SpecialViews/ResultView.xaml
@@ -1,21 +1,24 @@
 ﻿<!--  ReSharper disable UnusedMember.Global  -->
-<UserControl x:Class="LoadProfileGenerator.Views.SpecialViews.ResultView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             d:DesignHeight="380"
-             d:DesignWidth="510"
-             mc:Ignorable="d">
+<UserControl
+    x:Class="LoadProfileGenerator.Views.SpecialViews.ResultView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="380"
+    d:DesignWidth="510"
+    mc:Ignorable="d">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="35" />
         </Grid.RowDefinitions>
-        <GroupBox Name="Border1" Grid.Row="0"
-                          BorderBrush="Silver"
-                          BorderThickness="5">
+        <GroupBox
+            Name="Border1"
+            Grid.Row="0"
+            BorderBrush="Silver"
+            BorderThickness="5">
             <GroupBox.Header>
                 <Border Style="{StaticResource GroupBoxHeader}">
                     <TextBlock Text="General" />
@@ -32,16 +35,17 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                <Label Grid.Column="0"
-                               Content="Household name:"
-                               Target="{Binding ElementName=TxtHouseholdName}" />
-                <TextBox x:Name="TxtHouseholdName"
-                                 Grid.Row="0"
-                                 Grid.Column="1"
-                                 Height="23"
-                                 Margin="5,5,5,5"
-                                 Text="{Binding Path=Householdname,
-                                                Mode=OneWay}" />
+                <Label
+                    Grid.Column="0"
+                    Content="Household name:"
+                    Target="{Binding ElementName=TxtHouseholdName}" />
+                <TextBox
+                    x:Name="TxtHouseholdName"
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    Height="23"
+                    Margin="5,5,5,5"
+                    Text="{Binding Path=Householdname, Mode=OneWay}" />
                 <!--<Grid Grid.Row="1"
                               Grid.Column="0"
                               Grid.ColumnSpan="2">
@@ -100,13 +104,16 @@
                         </Grid>-->
             </Grid>
         </GroupBox>
-        <GroupBox BorderBrush="Silver" Grid.Row="1" BorderThickness="5">
+        <GroupBox
+            Grid.Row="1"
+            BorderBrush="Silver"
+            BorderThickness="5">
             <GroupBox.Header>
                 <Border Style="{StaticResource GroupBoxHeader}">
                     <TextBlock Text="Files" />
                 </Border>
             </GroupBox.Header>
-            <Grid x:Name="LayoutRoot">
+            <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="auto" />
                     <ColumnDefinition Width="*" />
@@ -119,42 +126,49 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock Grid.ColumnSpan="2" TextWrapping="WrapWithOverflow">
-                            Double clicking on a file will try to open it with the programm associated with the file in windows.
+                    Double clicking on a file will try to open it with the programm associated with the file in windows.
                 </TextBlock>
 
 
-                <Label Grid.Row="1"
-                               Grid.Column="0"
-                               HorizontalAlignment="Left"
-                               Content="Filter" />
-                <TextBox x:Name="TxtFilter"
-                                 Grid.Row="1"
-                                 Grid.Column="1"
-                                 Height="23"
-                                 Margin="5,5,5,5"
-                                 KeyUp="TxtFilterKeyUp" />
-                <ListView x:Name="LstFiles"
-                                  Grid.Row="2"
-                                  Grid.Column="0"
-                                  Grid.ColumnSpan="2"
-                                  MinHeight="150"
-                                  Margin="5"
-                                  ItemsSource="{Binding FilteredResultFiles}"
-                                  MouseDoubleClick="LstFilesMouseDoubleClick">
+                <Label
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    HorizontalAlignment="Left"
+                    Content="Filter" />
+                <TextBox
+                    x:Name="TxtFilter"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Height="23"
+                    Margin="5,5,5,5"
+                    KeyUp="TxtFilterKeyUp" />
+                <ListView
+                    x:Name="LstFiles"
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    MinHeight="150"
+                    Margin="5"
+                    ItemsSource="{Binding FilteredResultFiles}"
+                    MouseDoubleClick="LstFilesMouseDoubleClick">
                     <ListView.View>
                         <GridView>
-                            <GridViewColumn Width="Auto"
-                                                    DisplayMemberBinding="{Binding Name}"
-                                                    Header="Name" />
-                            <GridViewColumn Width="Auto"
-                                                    DisplayMemberBinding="{Binding FileName}"
-                                                    Header="Filename" />
-                            <GridViewColumn Width="Auto"
-                                                    DisplayMemberBinding="{Binding PrettySize}"
-                                                    Header="Size" />
-                            <GridViewColumn Width="Auto"
-                                                    DisplayMemberBinding="{Binding FullFileName}"
-                                                    Header="FullFilename" />
+                            <GridViewColumn
+                                Width="Auto"
+                                DisplayMemberBinding="{Binding Name}"
+                                Header="Name" />
+                            <GridViewColumn
+                                Width="Auto"
+                                DisplayMemberBinding="{Binding FileName}"
+                                Header="Filename" />
+                            <GridViewColumn
+                                Width="Auto"
+                                DisplayMemberBinding="{Binding PrettySize}"
+                                Header="Size" />
+                            <GridViewColumn
+                                Width="Auto"
+                                DisplayMemberBinding="{Binding FullFileName}"
+                                Header="FullFilename" />
                         </GridView>
                     </ListView.View>
                 </ListView>
@@ -162,16 +176,18 @@
 
             </Grid>
         </GroupBox>
-        <StackPanel Grid.Row="2"
-                    HorizontalAlignment="Right"
-                    Orientation="Horizontal">
+        <StackPanel
+            Grid.Row="2"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
 
-            <Button Name="Close"
-                    Width="75"
-                    Height="23"
-                    HorizontalAlignment="Right"
-                    Click="CloseClick"
-                    Content="Close" />
+            <Button
+                Name="Close"
+                Width="75"
+                Height="23"
+                HorizontalAlignment="Right"
+                Click="CloseClick"
+                Content="Close" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/WpfApplication1/Views/SpecialViews/ResultView.xaml
+++ b/WpfApplication1/Views/SpecialViews/ResultView.xaml
@@ -9,43 +9,40 @@
              mc:Ignorable="d">
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="35" />
         </Grid.RowDefinitions>
-        <ScrollViewer Name="ScrollViewer1"
-                      Margin="0,0,0,0"
-                      VerticalScrollBarVisibility="Auto">
-            <StackPanel>
-                <GroupBox Name="Border1"
+        <GroupBox Name="Border1" Grid.Row="0"
                           BorderBrush="Silver"
                           BorderThickness="5">
-                    <GroupBox.Header>
-                        <Border Style="{StaticResource GroupBoxHeader}">
-                            <TextBlock Text="General" />
-                        </Border>
-                    </GroupBox.Header>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="5*" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Label Grid.Column="0"
+            <GroupBox.Header>
+                <Border Style="{StaticResource GroupBoxHeader}">
+                    <TextBlock Text="General" />
+                </Border>
+            </GroupBox.Header>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="5*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Label Grid.Column="0"
                                Content="Household name:"
                                Target="{Binding ElementName=TxtHouseholdName}" />
-                        <TextBox x:Name="TxtHouseholdName"
+                <TextBox x:Name="TxtHouseholdName"
                                  Grid.Row="0"
                                  Grid.Column="1"
                                  Height="23"
                                  Margin="5,5,5,5"
                                  Text="{Binding Path=Householdname,
                                                 Mode=OneWay}" />
-                        <!--<Grid Grid.Row="1"
+                <!--<Grid Grid.Row="1"
                               Grid.Column="0"
                               Grid.ColumnSpan="2">
                             <Grid.ColumnDefinitions>
@@ -101,42 +98,42 @@
                                      Text="{Binding SimEndtime,
                                                     Mode=OneWay}" />
                         </Grid>-->
-                    </Grid>
-                </GroupBox>
-                <GroupBox BorderBrush="Silver" BorderThickness="5">
-                    <GroupBox.Header>
-                        <Border Style="{StaticResource GroupBoxHeader}">
-                            <TextBlock Text="Files" />
-                        </Border>
-                    </GroupBox.Header>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <TextBlock Grid.ColumnSpan="2" TextWrapping="WrapWithOverflow">
+            </Grid>
+        </GroupBox>
+        <GroupBox BorderBrush="Silver" Grid.Row="1" BorderThickness="5">
+            <GroupBox.Header>
+                <Border Style="{StaticResource GroupBoxHeader}">
+                    <TextBlock Text="Files" />
+                </Border>
+            </GroupBox.Header>
+            <Grid x:Name="LayoutRoot">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.ColumnSpan="2" TextWrapping="WrapWithOverflow">
                             Double clicking on a file will try to open it with the programm associated with the file in windows.
-                        </TextBlock>
+                </TextBlock>
 
 
-                        <Label Grid.Row="1"
+                <Label Grid.Row="1"
                                Grid.Column="0"
                                HorizontalAlignment="Left"
                                Content="Filter" />
-                        <TextBox x:Name="TxtFilter"
+                <TextBox x:Name="TxtFilter"
                                  Grid.Row="1"
                                  Grid.Column="1"
                                  Height="23"
                                  Margin="5,5,5,5"
                                  KeyUp="TxtFilterKeyUp" />
-                        <ListView x:Name="LstFiles"
+                <ListView x:Name="LstFiles"
                                   Grid.Row="2"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
@@ -144,30 +141,28 @@
                                   Margin="5"
                                   ItemsSource="{Binding FilteredResultFiles}"
                                   MouseDoubleClick="LstFilesMouseDoubleClick">
-                            <ListView.View>
-                                <GridView>
-                                    <GridViewColumn Width="Auto"
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Width="Auto"
                                                     DisplayMemberBinding="{Binding Name}"
                                                     Header="Name" />
-                                    <GridViewColumn Width="Auto"
+                            <GridViewColumn Width="Auto"
                                                     DisplayMemberBinding="{Binding FileName}"
                                                     Header="Filename" />
-                                    <GridViewColumn Width="Auto"
+                            <GridViewColumn Width="Auto"
                                                     DisplayMemberBinding="{Binding PrettySize}"
                                                     Header="Size" />
-                                    <GridViewColumn Width="Auto"
+                            <GridViewColumn Width="Auto"
                                                     DisplayMemberBinding="{Binding FullFileName}"
                                                     Header="FullFilename" />
-                                </GridView>
-                            </ListView.View>
-                        </ListView>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
 
 
-                    </Grid>
-                </GroupBox>
-            </StackPanel>
-        </ScrollViewer>
-        <StackPanel Grid.Row="1"
+            </Grid>
+        </GroupBox>
+        <StackPanel Grid.Row="2"
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
 


### PR DESCRIPTION
While working with the LoadProfileGenerator it bothered me that I was not able to scroll (vertical and horizontal) in the big ListView in the ResultView. So i fixed it.

Before:

![grafik](https://github.com/FZJ-IEK3-VSA/LoadProfileGenerator/assets/38386858/f042c342-ff9b-4ec7-ab58-c1767106b47f)

With the mouse over the listview scrolling did not work.

After:

![grafik](https://github.com/FZJ-IEK3-VSA/LoadProfileGenerator/assets/38386858/b70e3739-d826-4649-a9cf-243c7f538edf)

I hope that the solution is okay. The code comparison is slightly confusing, because the XAML Styler reformatted it. I mainly removed the StackPanel and put all GroupBoxes in the top level Grid.

Best Regards
Lukas